### PR TITLE
Wrap the .Close() method for the tablet service in a try-catch block.…

### DIFF
--- a/TabletSupport/TabletService.cs
+++ b/TabletSupport/TabletService.cs
@@ -119,7 +119,13 @@ namespace DynamicDraw.TabletSupport
                     winTabData = null;
                 }
 
-                winTabContext?.Close();
+                // This sometimes throws an error even with a null check, in which case it's already closed/invalid.
+                try
+                {
+                    winTabContext?.Close();
+                }
+                catch { }
+
                 disposedValue = true;
             }
         }


### PR DESCRIPTION
… It sometimes fails with invalid context, and when it does, it's already closed/invalid.