### PR TITLE
Update the Jagged smoothing to force aliasing with any brush

### DIFF
--- a/BrushSettings.cs
+++ b/BrushSettings.cs
@@ -601,7 +601,7 @@ namespace DynamicDraw
             SizeChange = 0;
             RotChange = 0;
             AlphaChange = 0;
-            Smoothing = CmbxSmoothing.Smoothing.Jagged;
+            Smoothing = CmbxSmoothing.Smoothing.Normal;
             Symmetry = SymmetryMode.None;
             CmbxTabPressureBrushAlpha = 0;
             CmbxTabPressureBrushDensity = 0;

--- a/Gui/DynamicDrawWindow.cs
+++ b/Gui/DynamicDrawWindow.cs
@@ -1658,7 +1658,8 @@ namespace DynamicDraw
                     || cmbxBlendMode.SelectedIndex != (int)BlendMode.Normal
                     || chkbxLockAlpha.Checked
                     || chkbxSeamlessDrawing.Checked
-                    || !chkbxColorizeBrush.Checked;
+                    || !chkbxColorizeBrush.Checked
+                    || (CmbxSmoothing.Smoothing)cmbxBrushSmoothing.SelectedIndex == CmbxSmoothing.Smoothing.Jagged;
 
                 // Overwrite blend mode and uncolorized images don't use the recolor matrix.
                 if (activeTool != Tool.Eraser)
@@ -1680,7 +1681,9 @@ namespace DynamicDraw
                     rotation -= sliderCanvasAngle.Value;
                 }
 
-                Bitmap bmpBrushRot = Utils.RotateImage(bmpBrushEffects, rotation);
+                Bitmap bmpBrushRot = (CmbxSmoothing.Smoothing)cmbxBrushSmoothing.SelectedValue == CmbxSmoothing.Smoothing.Jagged
+                    ? Utils.RotateImage(bmpBrushEffects, rotation, adjustedColor.A)
+                    : Utils.RotateImage(bmpBrushEffects, rotation);
 
                 //Rotating the brush increases image bounds, so brush space
                 //must increase to avoid making it visually shrink.


### PR DESCRIPTION
The Jagged smoothing option wasn't jagged with rotation. It turns out GDI+ also has no way of creating aliased rotations. All that is, is rounding each alpha to 0 or 255 (accounting for premultiplication) before drawing the pixel; this is now done with AliasImage() as a separate step in the RotateImage() function for Jagged smoothing. Since lockbits is forcibly used whenever jagged smoothing is set, RotateImage will always be called and this should work with any combination of blend mode, overwrite mode, transforms like rotate, etc. It's slightly slower to use lockbits and a little slower yet to loop twice through the image (this could be improved), but it seems fast enough.

The result is that when Jagged smoothing is on, all brushes are drawn with aliasing, even if the brush didn't have hard edges. This works well because the user doesn't have to go find separate brushes for pixel art. Since it's set to round between 0 and a max alpha, it actually works with transparency as a setting.

Also, the default smoothing mode is now Normal again so it's not in pixel art mode by default.