### PR TITLE
Fix a bug when parsing newer brushes

### DIFF
--- a/Abr/Internal/BrushSectionParser.cs
+++ b/Abr/Internal/BrushSectionParser.cs
@@ -3,7 +3,7 @@
 // ABR FileType Plugin for Paint.NET
 //
 // This software is provided under the MIT License:
-//   Copyright (c) 2012, 2013, 2017, 2018 Nicholas Hayes
+//   Copyright (c) 2012, 2013, 2017, 2018, 2022 Nicholas Hayes
 //
 // See LICENSE.txt for complete licensing and attribution information.
 //
@@ -109,7 +109,7 @@ namespace DynamicDraw.Abr.Internal
 
                 if (sig != PhotoshopSignature)
                 {
-                    return null;
+                    break;
                 }
 
                 uint sectionId = reader.ReadUInt32();


### PR DESCRIPTION
Some files were being rejected due to having a descriptor section length that is too short.